### PR TITLE
Add Automated Accessibility Tests

### DIFF
--- a/cookiecutter.json
+++ b/cookiecutter.json
@@ -12,5 +12,6 @@
   "cloud_provider": ["aws", "gcp"],
   "postgres_version": ["11","12", "13", "14"],
   "postgres_port": "5432",
-  "project_domain_name": "caktus-built.com"
+  "project_domain_name": "caktus-built.com",
+  "include_accessibility_tests": ["yes", "no"]
 }

--- a/hooks/post_gen_project.py
+++ b/hooks/post_gen_project.py
@@ -25,6 +25,9 @@ def clean_project():
     if "{{cookiecutter.project_type}}" == "django":
         shutil.rmtree((Path("./apps/search")))
 
+    if "{{cookiecutter.include_accessibility_tests}}" == "no":
+        Path("./apps/{{cookiecutter.primary_app}}/tests/test_accessibility.py").unlink()
+
     print("Renaming .envrc")
     Path(Path().cwd(), ".envrc_template").rename(Path(Path().cwd(), ".envrc"))
 

--- a/{{cookiecutter.project_app}}/.circleci/config.yml
+++ b/{{cookiecutter.project_app}}/.circleci/config.yml
@@ -100,8 +100,7 @@ jobs:
           name: install geckodriver
           command: |
             curl -L https://github.com/mozilla/geckodriver/releases/download/v0.30.0/geckodriver-v0.30.0-linux64.tar.gz > geckodriver.tar.gz
-            gzip -dk geckodriver.tar.gz
-            tar xvf geckodriver.tar
+            tar -zxvf geckodriver.tar
             sudo mv geckodriver /usr/local/bin
             sudo chown root:root /usr/local/bin/geckodriver
       {% endif %}

--- a/{{cookiecutter.project_app}}/.circleci/config.yml
+++ b/{{cookiecutter.project_app}}/.circleci/config.yml
@@ -95,6 +95,16 @@ jobs:
 
             pip install -r requirements/dev/dev.txt
       - save_cache_cmd
+      {% if cookiecutter.include_accessibility_tests == 'yes' %}
+      - run:
+          name: install geckodriver
+          command: |
+            curl -L https://github.com/mozilla/geckodriver/releases/download/v0.30.0/geckodriver-v0.30.0-linux64.tar.gz > geckodriver.tar.gz
+            gzip -dk geckodriver.tar.gz
+            tar xvf geckodriver.tar
+            sudo mv geckodriver /usr/local/bin
+            sudo chown root:root /usr/local/bin/geckodriver
+      {% endif %}
       - run:
         # This step is necessary to do the merge check in the
         # when condition below. Without it the local git cannot

--- a/{{cookiecutter.project_app}}/.github/workflows/tests.yml
+++ b/{{cookiecutter.project_app}}/.github/workflows/tests.yml
@@ -58,8 +58,7 @@ jobs:
       - name: Install geckodriver
         run: |
             curl -L https://github.com/mozilla/geckodriver/releases/download/v0.30.0/geckodriver-v0.30.0-linux64.tar.gz > geckodriver.tar.gz
-            gzip -dk geckodriver.tar.gz
-            tar xvf geckodriver.tar
+            tar -zxvf geckodriver.tar.gz
             sudo mv geckodriver /usr/local/bin
             sudo chown root:root /usr/local/bin/geckodriver
       {% endif %}

--- a/{{cookiecutter.project_app}}/.github/workflows/tests.yml
+++ b/{{cookiecutter.project_app}}/.github/workflows/tests.yml
@@ -51,6 +51,18 @@ jobs:
           python3 -m venv env
           . env/bin/activate
           make setup
+      {% if cookiecutter.include_accessibility_tests == 'yes' %}
+      #----------------------------------------------
+      # install geckodriver
+      #----------------------------------------------
+      - name: Install geckodriver
+        run: |
+            curl -L https://github.com/mozilla/geckodriver/releases/download/v0.30.0/geckodriver-v0.30.0-linux64.tar.gz > geckodriver.tar.gz
+            gzip -dk geckodriver.tar.gz
+            tar xvf geckodriver.tar
+            sudo mv geckodriver /usr/local/bin
+            sudo chown root:root /usr/local/bin/geckodriver
+      {% endif %}
       #----------------------------------------------
       # install your root project, if required
       #----------------------------------------------

--- a/{{cookiecutter.project_app}}/README.md
+++ b/{{cookiecutter.project_app}}/README.md
@@ -110,6 +110,10 @@ To install on Mac:
 ```
 $ brew install geckodriver
 ```
+
+{% if cookiecutter.testing_type == 'pytest' %}
+Note that accessibility tests run before migration checks, so any test errors in the accessibility tests will be output before any of the migration information. You may need to scroll up further than you expect in order to see the accessibility test errors, beginning with ``Accessibility violations:``
+{% endif %}
 {% endif %}
 
 NOTE: This project uses ``pip-tools``. If the dependency `.txt` files need to be

--- a/{{cookiecutter.project_app}}/README.md
+++ b/{{cookiecutter.project_app}}/README.md
@@ -93,6 +93,26 @@ Install Python dependencies with:
     ({{ cookiecutter.project_app }})$ make setup
 ```
 
+{% if cookiecutter.include_accessibility_tests == 'yes' %}
+This project has been set up to run automated accessibility tests,
+which require [geckodriver](https://github.com/mozilla/geckodriver/).
+
+To install on Linux:
+
+```
+$ curl -L https://github.com/mozilla/geckodriver/releases/download/v0.30.0/geckodriver-v0.30.0-linux64.tar.gz > geckodriver.tar.gz
+$ gzip -dk geckodriver.tar.gz
+$ tar xvf geckodriver.tar
+$ mv geckodriver /usr/local/bin
+```
+
+To install on Mac:
+
+```
+$ brew install geckodriver
+```
+{% endif %}
+
 NOTE: This project uses ``pip-tools``. If the dependency `.txt` files need to be
 updated:
 

--- a/{{cookiecutter.project_app}}/README.md
+++ b/{{cookiecutter.project_app}}/README.md
@@ -101,8 +101,7 @@ To install on Linux:
 
 ```
 $ curl -L https://github.com/mozilla/geckodriver/releases/download/v0.30.0/geckodriver-v0.30.0-linux64.tar.gz > geckodriver.tar.gz
-$ gzip -dk geckodriver.tar.gz
-$ tar xvf geckodriver.tar
+$ tar -zxvf geckodriver.tar.gz
 $ mv geckodriver /usr/local/bin
 ```
 

--- a/{{cookiecutter.project_app}}/README.md
+++ b/{{cookiecutter.project_app}}/README.md
@@ -102,7 +102,7 @@ To install on Linux:
 ```
 $ curl -L https://github.com/mozilla/geckodriver/releases/download/v0.30.0/geckodriver-v0.30.0-linux64.tar.gz > geckodriver.tar.gz
 $ tar -zxvf geckodriver.tar.gz
-$ mv geckodriver /usr/local/bin
+$ sudo mv geckodriver /usr/local/bin
 ```
 
 To install on Mac:

--- a/{{cookiecutter.project_app}}/apps/{{cookiecutter.primary_app}}/tests.py
+++ b/{{cookiecutter.project_app}}/apps/{{cookiecutter.primary_app}}/tests.py
@@ -1,4 +1,0 @@
-from django.test import TestCase
-
-
-# Create your tests here.

--- a/{{cookiecutter.project_app}}/apps/{{cookiecutter.primary_app}}/tests/test_accessibility.py
+++ b/{{cookiecutter.project_app}}/apps/{{cookiecutter.primary_app}}/tests/test_accessibility.py
@@ -1,0 +1,142 @@
+{% if cookiecutter.testing_type == 'django' %}
+from axe_selenium_python import Axe
+from selenium import webdriver
+
+from django.contrib.staticfiles.testing import StaticLiveServerTestCase
+from django.db import connections
+from django.shortcuts import reverse
+from django.test import override_settings
+
+
+@override_settings(
+    STATICFILES_STORAGE="whitenoise.storage.CompressedStaticFilesStorage"
+)
+class TestAccessibility(StaticLiveServerTestCase):
+    def setUp(self):
+        super().setUp()
+        # Set self.driver to be a headless Firefox browser.
+        options = webdriver.FirefoxOptions()
+        options.headless = True
+        self.driver = webdriver.Firefox(options=options)
+
+    def close_db_sessions(self, conn):
+        """
+        Close all database sessions.
+        Note: this should automatically happen on teardown, but for some reason
+        using Selenium with LiveServerTestCase doesn't automatically close all
+        database sessions on teardown, so this method does so explicitly.
+        Code based on:
+        stackoverflow.com/questions/53323775/database-still-in-use-after-a-selenium-test-in-django
+        """
+        close_sessions_query = """
+            SELECT pg_terminate_backend(pg_stat_activity.pid) FROM pg_stat_activity WHERE
+                datname = current_database() AND
+                pid <> pg_backend_pid();
+        """
+        with conn.cursor() as cursor:
+            try:
+                cursor.execute(close_sessions_query)
+            except OperationalError:
+                pass
+
+    def test_pages(self):
+        """Run accessibility tests on pages of the site."""
+        subtests = (
+            # page_name, page_url
+            ("homepage", reverse("home")),
+        )
+        for page_name, page_url in subtests:
+            with self.subTest(page_name=page_name, page_url=page_url):
+                url = self.live_server_url + page_url
+                self.driver.get(url)
+
+                axe = Axe(self.driver)
+                # Inject axe-core javascript into page.
+                axe.inject()
+                # Run axe accessibility checks.
+                results = axe.run()
+
+                # If there are violations, then write them to a file
+                if len(results["violations"]) > 0:
+                    violations_filename = (
+                        f"apps/{{cookiecutter.primary_app}}/tests/violations_{page_name}.json"
+                    )
+                    axe.write_results(results["violations"], violations_filename)
+
+                # Assert that there are no violations, or print out the titles
+                # of each of the violations.
+                violations_titles_list = [
+                    result["description"] for result in results["violations"]
+                ]
+                violations_titles_str = "\n".join(
+                    [f"  {title}" for title in violations_titles_list]
+                )
+                error_msg = (
+                    f"\n\nAccessibility violations:\n{violations_titles_str}\n\n"
+                    f"Violation results have been written to {violations_filename}"
+                )
+                self.assertEqual(0, len(violations_titles_list), error_msg)
+
+    def tearDown(self):
+        # Quit the browser.
+        self.driver.quit()
+
+        # Close all database connections (if they're still open).
+        for alias in connections:
+            connections[alias].close()
+            self.close_db_sessions(connections[alias])
+
+        super().tearDown()
+{% elif cookiecutter.testing_type == 'pytest' %}
+import pytest
+from axe_selenium_python import Axe
+from selenium import webdriver
+
+from django.shortcuts import reverse
+
+
+@pytest.mark.parametrize("page_name,page_url", [("homepage", reverse("home"))])
+def test_accessibility_on_pages(
+    live_server, django_db_serialized_rollback, settings, page_name, page_url
+):
+    """Run accessibility tests on pages of the site."""
+    # Set STATICFILES_STORAGE to not use unique suffixes on static files, so they
+    # can be found properly.
+    settings.STATICFILES_STORAGE = "whitenoise.storage.CompressedStaticFilesStorage"
+
+    # Set driver to be a headless Firefox browser.
+    options = webdriver.FirefoxOptions()
+    options.headless = True
+    driver = webdriver.Firefox(options=options)
+
+    url = live_server.url + page_url
+    driver.get(url)
+
+    axe = Axe(driver)
+    # Inject axe-core javascript into page.
+    axe.inject()
+    # Run axe accessibility checks.
+    results = axe.run()
+
+    # If there are violations, then write them to a file
+    if len(results["violations"]) > 0:
+        violations_filename = (
+            f"apps/{{cookiecutter.primary_app}}/tests/violations_{page_name}.json"
+        )
+        axe.write_results(results["violations"], violations_filename)
+
+    # Assert that there are no violations, or print out the titles
+    # of each of the violations.
+    violations_titles_list = [result["description"] for result in results["violations"]]
+    violations_titles_str = "\n".join(
+        [f"  {title}" for title in violations_titles_list]
+    )
+    error_msg = (
+        f"\n\nAccessibility violations:\n{violations_titles_str}\n\n"
+        f"Violation results have been written to {violations_filename}"
+    )
+    assert 0 == len(violations_titles_list), error_msg
+
+    # Quit the browser.
+    driver.quit()
+{% endif %}

--- a/{{cookiecutter.project_app}}/requirements/dev/dev.in
+++ b/{{cookiecutter.project_app}}/requirements/dev/dev.in
@@ -13,6 +13,9 @@ boto
 
 # For testing
 factory_boy
+{% if cookiecutter.include_accessibility_tests == 'yes' %}
+axe-selenium-python==2.1.6
+{% endif %}
 
 {% if cookiecutter.testing_type == 'pytest' %}
 pytest

--- a/{{cookiecutter.project_app}}/requirements/dev/dev.in
+++ b/{{cookiecutter.project_app}}/requirements/dev/dev.in
@@ -27,3 +27,7 @@ pytest-subtests
 {% if cookiecutter.project_type == 'django' %}
 beautifulsoup4
 {% endif %}
+
+{% if cookiecutter.project_type == 'wagtail' %}
+wagtail-factories
+{% endif %}

--- a/{{cookiecutter.project_app}}/{{cookiecutter.project_app}}/settings/base.py
+++ b/{{cookiecutter.project_app}}/{{cookiecutter.project_app}}/settings/base.py
@@ -272,7 +272,7 @@ WAGTAIL_SITE_NAME = "{{ cookiecutter.project_app }}"
 
 WAGTAILSEARCH_BACKENDS = {
     "default": {
-        "BACKEND": "wagtail.contrib.postgres_search.backend",
+        "BACKEND": "wagtail.search.backends.database",
         "SEARCH_CONFIG": "english",
     },
 }

--- a/{{cookiecutter.project_app}}/{{cookiecutter.project_app}}/settings/base.py
+++ b/{{cookiecutter.project_app}}/{{cookiecutter.project_app}}/settings/base.py
@@ -12,7 +12,9 @@ https://docs.djangoproject.com/en/3.0/ref/settings/
 
 # Build paths inside the project like this: os.path.join(BASE_DIR, ...)
 import os
-
+{% if cookiecutter.project_type == 'wagtail' %}
+import sys
+{% endif %}
 
 PROJECT_DIR = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
 BASE_DIR = os.path.dirname(PROJECT_DIR)
@@ -59,6 +61,18 @@ INSTALLED_APPS += [
     "wagtail.contrib.styleguide",
     "wagtail.contrib.modeladmin",
 ]
+
+{% if cookiecutter.project_type == 'wagtail' %}
+# Note: having "wagtail.contrib.search_promotions" installed prevents a bug
+# when running tests with Django's LiveServerTestCase. For more information,
+# see https://github.com/wagtail/wagtail/issues/1824.
+{% if cookiecutter.testing_type == 'django' %}
+if "test" in sys.argv and "wagtail.contrib.search_promotions" not in INSTALLED_APPS:
+{% elif cookiecutter.testing_type == 'pytest' %}
+if "pytest" in " ".join(sys.argv) and "wagtail.contrib.search_promotions" not in INSTALLED_APPS:
+{% endif %}
+    INSTALLED_APPS += ["wagtail.contrib.search_promotions"]
+{% endif %}
 
 WAGTAILSEARCH_BACKENDS = {
     'default': {

--- a/{{cookiecutter.project_app}}/{{cookiecutter.project_app}}/urls.py
+++ b/{{cookiecutter.project_app}}/{{cookiecutter.project_app}}/urls.py
@@ -27,8 +27,9 @@ urlpatterns += [
 {% endif %}
 
 urlpatterns += [
+
 {% if cookiecutter.project_type == "django" -%}
-    path("", HomePageView.as_view(), name='index'),
+    path("", HomePageView.as_view(), name="home"),
 {% endif %}
 {% if cookiecutter.project_type == "wagtail" -%}
     path("", include(wagtail_urls)),


### PR DESCRIPTION
This pull request adds support for automated accessibility tests (pytest or Django tests) when setting up a new project with `jade-truffle`:
 - Setting up a new project asks whether the developer wants to include accessibility tests. If the developer chooses ‘yes’, then a `{{cookiecutter.project_app}}/apps/{{cookiecutter.primary_app}}/tests/test_accessibility.py` file gets added to the new project, with the logic for testing the accessibility of various pages
 - the README has been updated with a section about setting up `geckodriver` (for Linux and Mac)
 - CircleCI and GitHub Actions configuration files have been updated to install `geckodriver`
 - the `{{cookiecutter.project_app}}/apps/{{cookiecutter.primary_app}}/tests.py` file has been removed (since there is now a `tests` directory instead of the `tests.py` file)
 - the Python requirements file has been updated to install the latest version of `axe-selenium-python` which uses [axe](https://www.deque.com/axe/), and `wagtail-factories`.

Note: the logic in this pull request only tests accessibility on the homepage (since that is the only page created when starting a project), though it should be easy to add more pages by adding to the `test_accessibility.py` file.

The idea behind this change is to more easily incorporate accessibility testing into Caktus projects. It should now be possible to run accessibility tests by default when a new project is created with jade-truffle (`make run-tests` or `python manage.py test` or `pytest` automatically runs accessibility tests with all other Python tests).

A note: the accessibility tests currently report several failures on the homepage, because the homepage currently has empty content. I’m going to leave the base.html template alone for now and let these issues be resolved in each appropriate project, rather than trying to fix them here.

When reviewing this pull request, make sure to test each of the following:
 - a Django project with Django tests
 - a Django project with pytest tests
 - a Wagtail project with Django tests
 - a Wagtail project with pytest tests

To test locally (for each of the 4 scenarios):
 - check out this branch locally
 - create a virtual environment for a new project
 - create a new project using this branch of jade-truffle `$ cookiecutter .`
 - install requirements (`pip install -r requirements/dev/dev.txt`)
 - try to run the tests (`python manage.py test` or `pytest`), and observe the errors


